### PR TITLE
Graham suggestions

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3,5 +3,30 @@
 version = 3
 
 [[package]]
+name = "anyhow"
+version = "1.0.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b26702f315f53b6071259e15dd9d64528213b44d61de1ec926eca7715d62203"
+
+[[package]]
 name = "aoc"
 version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "itertools",
+]
+
+[[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "itertools"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
+dependencies = [
+ "either",
+]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,3 +3,7 @@ name = "aoc"
 version = "0.1.0"
 authors = ["Shane Caldwell <caldwell.shane@gmail.com>"]
 edition = "2021"
+
+[dependencies]
+anyhow = "1.0.51"
+itertools = "0.10.1"

--- a/rust/src/aoc/day_01.rs
+++ b/rust/src/aoc/day_01.rs
@@ -5,24 +5,24 @@ use std::str::FromStr;
 
 static DAY: i16 = 1;
 
-fn count_increases(data: &Vec<i32>) -> i16 {
+fn count_increases(data: &[i32]) -> i16 {
     let mut count = 0;
     for idx in 1..data.len() {
         if data[idx] > data[idx - 1] {
             count += 1;
         }
     }
-    return count;
+    count
 }
 
-fn three_element_sums(data: &Vec<i32>) -> Vec<i32> {
+fn three_element_sums(data: &[i32]) -> Vec<i32> {
     let mut sums = Vec::<i32>::new();
     for (idx, _) in data.iter().enumerate() {
         if idx >= 2 {
             sums.push(data[idx - 2] + data[idx - 1] + data[idx])
         }
     }
-    return sums;
+    sums
 }
 
 pub fn run() {


### PR DESCRIPTION
Copying the body of the commit messages:

36f0f4a: **Appease clippy on day_01**

I ran [`cargo clippy`](https://github.com/rust-lang/rust-clippy) and did everything it told me to on `day_01.rs`.

9f513c9: **A few changes to day_02**

First, I added two dependencies:

- [`anyhow`](https://docs.rs/anyhow/1.0.51/anyhow/) for easy error handling—probably wouldn't just shove everything into a single error type in production, but it's great for Advent of Code
- [`itertools`](https://docs.rs/itertools/0.10.1/itertools/) for some iterator goodness, specifically [`collect_tuple`](https://docs.rs/itertools/0.10.1/itertools/trait.Itertools.html#method.collect_tuple)

Next up, I created an `enum Direction`; with only three options, it simplified `Moveable.update_position` and got rid some of `panic!`s. We also need to be able to parse a string into it, though, hence the `impl FromStr for Direction`, localizing the error handling there.

With that `FromStr`, I changed `parse_movement` to
- split into a tuple via `itertools`, and
- call `Direction::from_str` on the first item

One thing in the interest of brevity: I derived `Default` for the submarine types; this sets their numerical values to zero so we needn't write it all out explicitly.

Rather than hold the instructions explicitly in memory, I iterate over splitting the string & parsing the pieces directly.

Finally, I did whatever `cargo clippy` told me to, like removing `return` statements and switching `"\n"` to `'\n'` in one spot.


